### PR TITLE
Improve serialization with regards to attributes and style-settings

### DIFF
--- a/serialize.js
+++ b/serialize.js
@@ -28,6 +28,10 @@ function serializeElement(elem) {
 function isProperty(elem, key) {
     var type = typeof elem[key]
 
+    if (key === "style" && Object.keys(elem.style).length > 0) {
+      return true
+    }
+
     return elem.hasOwnProperty(key) &&
         (type === "string" || type === "boolean" || type === "number") &&
         key !== "nodeName" && key !== "className" && key !== "tagName" &&
@@ -76,6 +80,13 @@ function properties(elem) {
         if (isProperty(elem, key)) {
             props.push({ name: key, value: elem[key] })
         }
+    }
+
+    for (var ns in elem._attributes) {
+      for (var attribute in elem._attributes[ns]) {
+        var name = (ns !== "null" ? ns + ":" : "") + attribute
+        props.push({ name: name, value: elem._attributes[ns][attribute] })
+      }
     }
 
     if (elem.className) {

--- a/test/test-document.js
+++ b/test/test-document.js
@@ -315,18 +315,43 @@ function testDocument(document) {
     })
 
     test("input has type=text by default", function (assert) {
-        assert.equal(document.createElement("input").type, "text");
+        var elem = document.createElement("input")
+        assert.equal(elem.type, "text");
+        assert.equal(elemString(elem), "<input type=\"text\"></input>")
         assert.end()
     })
 
     test("can set and get attributes", function (assert) {
         var elem = document.createElement("div")
         assert.equal(elem.getAttribute("foo"), null)
+        assert.equal(elemString(elem), "<div></div>")
+
         elem.setAttribute("foo", "bar")
         assert.equal(elem.getAttribute("foo"), "bar")
+        assert.equal(elemString(elem), "<div foo=\"bar\"></div>")
+
         elem.removeAttribute("foo")
         assert.equal(elem.getAttribute("foo"), null)
+        assert.equal(elemString(elem), "<div></div>")
+
         assert.end()
+    })
+    
+    test("can set and set style properties", function(assert) {
+      var elem = document.createElement("div")
+      assert.equal(elemString(elem), "<div></div>")
+
+      elem.style.color = "red";
+      assert.equal(elem.style.color, "red")
+      assert.equal(elemString(elem), "<div style=\"color:red;\"></div>")
+
+      elem.style.background = "blue";
+      assert.equal(elem.style.color, "red")
+      assert.equal(elem.style.background, "blue")
+      assert.equal(elemString(elem),
+                   "<div style=\"color:red;background:blue;\"></div>")
+
+      assert.end()
     })
 
     test("can set and get namespaced attributes", function(assert) {


### PR DESCRIPTION
Hi,

I was trying to play around with server-side rending DOMDocument's created using *min-document*, and I stumbled upon the fact that `serializeElement` doesn't handle attributes or style-settings very well.

I have attempted to add some functionality to cover this - but it seems like there might be some left-over stuff from a previous version of how attributes where handle, maybe?

There is an issue with running the tests in the browser, as they tend to serialise elements slightly different. E.g. `<div style="color:red;"></div>` vs `<div style="color: red; "></div>`. Or how how to handle shorthand style syntax, where browser sometimes expands it.. I'm not sure how thoroughly this implementation should match the browsers?

But anyway, it would be awesome to have `serializeElement` actually serialise attributes and style-settings as well - and this PR is an effort towards this, but might not be the final solution. So I would love some discussion or input on how this should best be achieved...

Kind Regards
Morten