### PR TITLE
Improvements to namespaces and attributes in serialization

### DIFF
--- a/dom-element.js
+++ b/dom-element.js
@@ -97,13 +97,13 @@ DOMElement.prototype.setAttributeNS =
     function _Element_setAttributeNS(namespace, name, value) {
         var colonPosition = name.indexOf(":")
         var localName = colonPosition > -1 ? name.substr(colonPosition + 1) : name
-        var attributes = this._attributes[namespace] || (this._attributes[namespace] = {})
-        attributes[localName] = value
+        var attributes = namespace === null ? this : (this._attributes[namespace] || (this._attributes[namespace] = {}))
+        attributes[localName] = String(value)
     }
 
 DOMElement.prototype.getAttributeNS =
     function _Element_getAttributeNS(namespace, name) {
-        var attributes = this._attributes[namespace];
+        var attributes = namespace === null ? this : this._attributes[namespace];
         if (!(attributes && typeof attributes[name] === "string")) {
             return null
         }
@@ -113,7 +113,7 @@ DOMElement.prototype.getAttributeNS =
 
 DOMElement.prototype.removeAttributeNS =
     function _Element_removeAttributeNS(namespace, name) {
-        var attributes = this._attributes[namespace];
+        var attributes = namespace === null ? this : this._attributes[namespace];
         if (attributes) {
             delete attributes[name]
         }

--- a/serialize.js
+++ b/serialize.js
@@ -49,7 +49,10 @@ function stylify(styles) {
     var attr = ""
     Object.keys(styles).forEach(function (key) {
         var value = styles[key]
-        attr += key + ":" + value + ";"
+          , name = key.replace(/([A-Z])/g, function(_, c) {
+                                             return '-' + c.toLowerCase();
+                                           })
+        attr += name + ": " + value + "; "
     })
     return attr
 }

--- a/serialize.js
+++ b/serialize.js
@@ -94,8 +94,7 @@ function properties(elem) {
 
     for (var ns in elem._attributes) {
       for (var attribute in elem._attributes[ns]) {
-        var name = (ns !== "null" ? ns + ":" : "") + attribute
-        props.push({ name: name, value: elem._attributes[ns][attribute] })
+        props.push({ name: attribute, value: elem._attributes[ns][attribute] })
       }
     }
 

--- a/serialize.js
+++ b/serialize.js
@@ -5,6 +5,10 @@ function serializeElement(elem) {
 
     var tagname = elem.tagName
 
+    var voidElements = ['area', 'base', 'br', 'col', 'embed', 'hr', 'img',
+                        'input', 'keygen', 'link', 'menuitem', 'meta', 'param',
+                        'source', 'track', 'wbr']
+
     if (elem.namespaceURI === "http://www.w3.org/1999/xhtml") {
         tagname = tagname.toLowerCase()
     }
@@ -20,7 +24,10 @@ function serializeElement(elem) {
         strings.push(node.toString())
     })
 
-    strings.push("</" + tagname + ">")
+    if (!(elem.namespaceURI === "http://www.w3.org/1999/xhtml"
+     && voidElements.indexOf(tagname) !== -1)) {
+        strings.push("</" + tagname + ">")
+    }
 
     return strings.join("")
 }

--- a/test/test-document.js
+++ b/test/test-document.js
@@ -376,13 +376,13 @@ function testDocument(document) {
 
       elem.style.color = "red";
       assert.equal(elem.style.color, "red")
-      assert.equal(elemString(elem), "<div style=\"color:red;\"></div>")
+      assert.equal(elemString(elem), "<div style=\"color: red; \"></div>")
 
-      elem.style.background = "blue";
+      elem.style.backgroundColor = "blue";
       assert.equal(elem.style.color, "red")
-      assert.equal(elem.style.background, "blue")
+      assert.equal(elem.style.backgroundColor, "blue")
       assert.equal(elemString(elem),
-                   "<div style=\"color:red;background:blue;\"></div>")
+                   "<div style=\"color: red; background-color: blue; \"></div>")
 
       assert.end()
     })

--- a/test/test-document.js
+++ b/test/test-document.js
@@ -58,6 +58,24 @@ function testDocument(document) {
         assert.end()
     })
 
+    test("can assign attributes through .[attr] and .getAttribute(attr)",
+                                                            function(assert) {
+        var div = document.createElement("div")
+        div.id = "foo"
+        assert.equals(div.id, "foo")
+        assert.equals(div.getAttribute("id"), "foo")
+        assert.equals(elemString(div), "<div id=\"foo\"></div>")
+
+        var div2 = document.createElement("div")
+        div2.setAttribute("id", "bar")
+        assert.equals(div2.id, "bar")
+        assert.equals(div2.getAttribute("id"), "bar")
+        assert.equals(elemString(div2), "<div id=\"bar\"></div>")
+
+        cleanup()
+        assert.end()
+    })
+
     test("can getElementById", function (assert) {
 
         function append_div(id, parent) {
@@ -317,7 +335,22 @@ function testDocument(document) {
     test("input has type=text by default", function (assert) {
         var elem = document.createElement("input")
         assert.equal(elem.type, "text");
-        assert.equal(elemString(elem), "<input type=\"text\"></input>")
+
+        if (document.onload) {
+          // These tests are how the browser actually handles input-elements,
+          // which we don't try an emulate as it is somewhat complicated and
+          // is a bit of an edge-case
+          assert.equal(elem.getAttribute("type"), null);
+          assert.equal(elemString(elem), "<input>")
+        }
+
+        elem.setAttribute('type', 'text')
+        assert.equal(elem.type, "text");
+        assert.equal(elem.getAttribute("type"), "text");
+        // Now that we have explicitly set the type, both min-document and
+        // browers agree what the serialization should be...
+        assert.equal(elemString(elem), "<input type=\"text\">")
+
         assert.end()
     })
 

--- a/test/test-document.js
+++ b/test/test-document.js
@@ -394,8 +394,11 @@ function testDocument(document) {
         assert.equal(elem.getAttributeNS(ns, "myattr"), blankAttributeNS())
         elem.setAttributeNS(ns, "myns:myattr", "the value")
         assert.equal(elem.getAttributeNS(ns, "myattr"), "the value")
+        assert.equal(elemString(elem),"<div myattr=\"the value\"></div>")
+
         elem.removeAttributeNS(ns, "myattr")
         assert.equal(elem.getAttributeNS(ns, "myattr"), blankAttributeNS())
+        assert.equal(elemString(elem),"<div></div>")
 
         // Should work much like get/setAttribute when namespace is null.
         assert.equal(elem.getAttributeNS(null, "foo"), blankAttributeNS())
@@ -403,9 +406,11 @@ function testDocument(document) {
         elem.setAttributeNS(null, "foo", "bar")
         assert.equal(elem.getAttributeNS(null, "foo"), "bar")
         assert.equal(elem.getAttribute("foo"), "bar")
+        assert.equal(elemString(elem),"<div foo=\"bar\"></div>")
         elem.removeAttributeNS(null, "foo")
         assert.equal(elem.getAttributeNS(null, "foo"), blankAttributeNS())
         assert.equal(elem.getAttribute("foo"), null)
+        assert.equal(elemString(elem),"<div></div>")
         assert.end()
     })
 


### PR DESCRIPTION
Hi,

I started out by adding test-cases for the serialisation, and found a few issues once I compared to how browsers (ehh, phantomjs) does it. I found a few discrepancies that I have addressed. Additionally I ensured that `elem.[attr]` is equivalent to `elem.getAttribute("[attr]")`.

So the new or fixed features are:

- `elem.[attr]` is equivalent to `elem.getAttribute("[attr]")`
- `elem.style.backgroundColor` and other CSS properties that include hyphens are now serialised correctly
- Namespaced attributes are now serialised correctly (I implemented it wrong in the previous PR)
- Void-elements are now serialised as void-elements - ie, they do not have an end-tag. This is only done if the documents namespace is the HTML namespace.

Known differences between min-document and browsers:

- `document.createElement('input').getAttribute('type')` is `null` in browsers, but `text` in min-document. This is because in both browsers and min-document, `document.createElement('input').type` is `text` - ie, in browsers there is a difference between `.type` and `.getAttribute('type');`.
- `document.createElement('input')` is serialised as `<input>` in browsers, and `<input type="text">` in min-document. This is the same issue as the previous discrepancy. 

Kind regards
Morten