### PR TITLE
Suppport for innerText

### DIFF
--- a/serialize.js
+++ b/serialize.js
@@ -12,8 +12,8 @@ function serializeElement(elem) {
     strings.push("<" + tagname +
         properties(elem) + datasetify(elem) + ">")
 
-    if (elem.textContent) {
-        strings.push(elem.textContent)
+    if (elem.textContent || elem.innerText) {
+        strings.push(elem.textContent || elem.innerText)
     }
 
     elem.childNodes.forEach(function (node) {
@@ -35,7 +35,7 @@ function isProperty(elem, key) {
     return elem.hasOwnProperty(key) &&
         (type === "string" || type === "boolean" || type === "number") &&
         key !== "nodeName" && key !== "className" && key !== "tagName" &&
-        key !== "textContent" && key !== "namespaceURI"
+        key !== "textContent" && key !== "innerText" && key !== "namespaceURI"
 }
 
 function stylify(styles) {

--- a/test/test-dom-element.js
+++ b/test/test-dom-element.js
@@ -57,4 +57,12 @@ function testDomElement(document) {
         cleanup()
         assert.end()
     })
+
+    test("does not serialize innerText as an attribute", function(assert) {
+      var div = document.createElement("div")
+      div.innerText = "Test"
+      assert.equal(div.toString(), "<div>Test</div>")
+      cleanup()
+      assert.end()
+    })
 }


### PR DESCRIPTION
Adds support for `innerText` unless the superior `textContent` is used. Thanks!