### PR TITLE
Implement getElementsByTagName for Document and DOMElement

### DIFF
--- a/docs.mli
+++ b/docs.mli
@@ -43,11 +43,15 @@ type DOMElement := {
     addEventListener: addEventListener,
     dispatchEvent: dispatchEvent,
     focus: () => void,
-    toString: (this: DOMElement) => String
+    toString: (this: DOMElement) => String,
     getElementsByClassName: (
         this: DOMElement,
         className: String
-    ) => Array<DOMElement>
+    ) => Array<DOMElement>,
+    getElementsByTagName: (
+        this: DOMElement,
+        tagName: String
+    ) => Array<DOMElement>,
 }
 
 type DocumentFragment := {
@@ -67,6 +71,7 @@ type DocumentFragment := {
 
 type Document := {
     body: DOMElement,
+    childNodes: Array<DOMChild>,
     documentElement: DOMElement,
 
     createTextNode: (this: Document, value: String) => DOMText,
@@ -75,17 +80,22 @@ type Document := {
         this: Document,
         namespace: String | null,
         tagName: String
-    ) => DOMElement
+    ) => DOMElement,
     createDocumentFragment: (this: Document) => DocumentFragment,
     createEvent: () => Event,
     getElementById: (
         this: Document,
         id: String,
         parent?: DOMElement
-    ) => null | DOMElement
+    ) => null | DOMElement,
     getElementsByClassName: (
         this: Document,
         className: String
+        parent?: DOMElement
+    ) => Array<DOMElement>,
+    getElementsByTagName: (
+        this: Document,
+        tagName: String
         parent?: DOMElement
     ) => Array<DOMElement>
 }

--- a/document.js
+++ b/document.js
@@ -17,6 +17,7 @@ function Document() {
     this.documentElement = this.createElement("html")
     this.documentElement.appendChild(this.head)
     this.documentElement.appendChild(this.body)
+    this.childNodes = [this.documentElement]
 }
 
 var proto = Document.prototype;
@@ -80,6 +81,24 @@ proto.getElementsByClassName = function getElementsByClassName(classNames, paren
         if (classes.every(function (item) {
             return nodeClasses.indexOf(item) !== -1
         })) {
+            elems.push(node)
+        }
+    })
+
+    return elems
+}
+
+proto.getElementsByTagName = function getElementsByTagName(tagName, parent) {
+    tagName = tagName.toLowerCase()
+
+    if (!parent) {
+        parent = this
+    }
+
+    var elems = []
+
+    domWalk(parent.childNodes, function (node) {
+        if (tagName === '*' || node.tagName.toLowerCase() === tagName) {
             elems.push(node)
         }
     })

--- a/dom-element.js
+++ b/dom-element.js
@@ -147,3 +147,7 @@ DOMElement.prototype.toString = function _Element_toString() {
 DOMElement.prototype.getElementsByClassName = function _Element_getElementsByClassName(classNames) {
     return this.ownerDocument.getElementsByClassName(classNames, this)
 }
+
+DOMElement.prototype.getElementsByTagName = function _Element_getElementsByTagName(tagName) {
+    return this.ownerDocument.getElementsByTagName(tagName, this)
+}

--- a/test/test-document.js
+++ b/test/test-document.js
@@ -341,7 +341,7 @@ function testDocument(document) {
 
         assert.end()
     })
-    
+
     test("can set and set style properties", function(assert) {
       var elem = document.createElement("div")
       assert.equal(elemString(elem), "<div></div>")
@@ -378,6 +378,43 @@ function testDocument(document) {
         elem.removeAttributeNS(null, "foo")
         assert.equal(elem.getAttributeNS(null, "foo"), blankAttributeNS())
         assert.equal(elem.getAttribute("foo"), null)
+        assert.end()
+    })
+
+    test("can getElementsByTagName", function(assert) {
+        var parent = document.createElement("div")
+        var child1 = document.createElement("span")
+        var child2 = document.createElement("span")
+
+        child1.id = "foo"
+        child2.id = "bar"
+
+        child1.appendChild(child2)
+        parent.appendChild(child1)
+        document.body.appendChild(parent)
+
+        var elems = document.getElementsByTagName("SPAN")
+
+        assert.equal(elems.length, 2)
+        assert.equal(elems[0].id, "foo")
+        assert.equal(elems[1].id, "bar")
+
+        cleanup()
+        assert.end()
+    })
+
+    test("can getElementsByTagName with *", function(assert) {
+        document.body.appendChild(document.createElement("div"))
+
+        var elems = document.getElementsByTagName("*")
+
+        assert.equal(elems.length, 4)
+        assert.equal(elems[0].tagName, "HTML")
+        assert.equal(elems[1].tagName, "HEAD")
+        assert.equal(elems[2].tagName, "BODY")
+        assert.equal(elems[3].tagName, "DIV")
+
+        cleanup()
         assert.end()
     })
 

--- a/test/test-dom-element.js
+++ b/test/test-dom-element.js
@@ -65,4 +65,43 @@ function testDomElement(document) {
       cleanup()
       assert.end()
     })
+
+    test("can getElementsByTagName", function(assert) {
+        var parent = document.createElement("div")
+        var child1 = document.createElement("span")
+        var child2 = document.createElement("span")
+
+        child1.id = "foo"
+        child2.id = "bar"
+
+        child1.appendChild(child2)
+        parent.appendChild(child1)
+
+        var elems = parent.getElementsByTagName("SPAN")
+
+        assert.equal(elems.length, 2)
+        assert.equal(elems[0].id, "foo")
+        assert.equal(elems[1].id, "bar")
+
+        cleanup()
+        assert.end()
+    })
+
+    test("can getElementsByTagName with *", function(assert) {
+        var e1 = document.createElement("div")
+        var e2 = document.createElement("p")
+        var e3 = document.createElement("span")
+
+        e1.appendChild(e2)
+        e2.appendChild(e3)
+
+        var elems = e1.getElementsByTagName("*")
+
+        assert.equal(elems.length, 2)
+        assert.equal(elems[0].tagName, "P")
+        assert.equal(elems[1].tagName, "SPAN")
+
+        cleanup()
+        assert.end()
+    })
 }


### PR DESCRIPTION
Mostly copied from the implementation of getElementsByClassName. Adds childNodes to Document since it was missing and needed here too