### PR TITLE
Implement Document.prototype.createComment

### DIFF
--- a/docs.mli
+++ b/docs.mli
@@ -1,3 +1,14 @@
+type Comment := {
+    data: String,
+    length: Number,
+    nodeName: "#comment",
+    nodeType: 8,
+    nodeValue: String,
+    ownerDoucment: null | Document,
+
+    toString: (this: Comment) => String
+}
+
 type DOMText := {
     data: String,
     type: "DOMTextNode",
@@ -74,6 +85,7 @@ type Document := {
     childNodes: Array<DOMChild>,
     documentElement: DOMElement,
 
+    createComment: (this: Document, data: String) => Commment,
     createTextNode: (this: Document, value: String) => DOMText,
     createElement: (this: Document, tagName: String) => DOMElement,
     createElementNS: (

--- a/document.js
+++ b/document.js
@@ -1,5 +1,6 @@
 var domWalk = require("dom-walk")
 
+var Comment = require("./dom-comment.js")
 var DOMText = require("./dom-text.js")
 var DOMElement = require("./dom-element.js")
 var DocumentFragment = require("./dom-fragment.js")
@@ -42,6 +43,10 @@ proto.createEvent = function createEvent(family) {
     return new Event(family)
 }
 
+proto.createComment = function createComment(data) {
+    return new Comment(data, this)
+}
+
 proto.getElementById = function getElementById(id, parent) {
     if (!parent) {
         parent = this.body
@@ -75,13 +80,15 @@ proto.getElementsByClassName = function getElementsByClassName(classNames, paren
     var elems = []
 
     domWalk(parent, function (node) {
-        var nodeClassName = node.className || ""
-        var nodeClasses = nodeClassName.split(" ")
+        if (node.nodeType === 1) {
+            var nodeClassName = node.className || ""
+            var nodeClasses = nodeClassName.split(" ")
 
-        if (classes.every(function (item) {
-            return nodeClasses.indexOf(item) !== -1
-        })) {
-            elems.push(node)
+            if (classes.every(function (item) {
+                return nodeClasses.indexOf(item) !== -1
+            })) {
+                elems.push(node)
+            }
         }
     })
 
@@ -98,7 +105,7 @@ proto.getElementsByTagName = function getElementsByTagName(tagName, parent) {
     var elems = []
 
     domWalk(parent.childNodes, function (node) {
-        if (tagName === '*' || node.tagName.toLowerCase() === tagName) {
+        if (node.nodeType === 1 && (tagName === '*' || node.tagName.toLowerCase() === tagName)) {
             elems.push(node)
         }
     })

--- a/dom-comment.js
+++ b/dom-comment.js
@@ -1,0 +1,19 @@
+module.exports = Comment
+
+function Comment(data, owner) {
+    if (!(this instanceof Comment)) {
+        return new Comment(data, owner)
+    }
+
+    this.data = data
+    this.nodeValue = data
+    this.length = data.length
+    this.ownerDocument = owner || null
+}
+
+Comment.prototype.nodeType = 8
+Comment.prototype.nodeName = "#comment"
+
+Comment.prototype.toString = function _Comment_toString() {
+    return "[object Comment]"
+}

--- a/dom-element.js
+++ b/dom-element.js
@@ -1,7 +1,7 @@
 var dispatchEvent = require("./event/dispatch-event.js")
 var addEventListener = require("./event/add-event-listener.js")
 var removeEventListener = require("./event/remove-event-listener.js")
-var serializeElement = require("./serialize.js")
+var serializeNode = require("./serialize.js")
 
 var htmlns = "http://www.w3.org/1999/xhtml"
 
@@ -141,7 +141,7 @@ DOMElement.prototype.focus = function _Element_focus() {
 }
 
 DOMElement.prototype.toString = function _Element_toString() {
-    return serializeElement(this)
+    return serializeNode(this)
 }
 
 DOMElement.prototype.getElementsByClassName = function _Element_getElementsByClassName(classNames) {

--- a/serialize.js
+++ b/serialize.js
@@ -1,4 +1,13 @@
-module.exports = serializeElement
+module.exports = serializeNode
+
+function serializeNode(node) {
+    switch (node.nodeType) {
+        case 8:
+            return "<!--" + node.data + "-->"
+        default:
+            return serializeElement(node)
+    }
+}
 
 function serializeElement(elem) {
     var strings = []
@@ -17,7 +26,7 @@ function serializeElement(elem) {
     }
 
     elem.childNodes.forEach(function (node) {
-        strings.push(node.toString())
+        strings.push(serializeNode(node))
     })
 
     strings.push("</" + tagname + ">")

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,14 @@
 var testDocument = require("./test-document")
 var testDomElement = require("./test-dom-element")
+var testDomComment = require("./test-dom-comment")
 var document = require("../index")
 
 testDocument(document)
 testDomElement(document)
+testDomComment(document)
 
 if (typeof window !== "undefined" && window.document) {
     testDocument(window.document)
     testDomElement(window.document)
+    testDomComment(window.document)
 }

--- a/test/test-dom-comment.js
+++ b/test/test-dom-comment.js
@@ -1,0 +1,20 @@
+var test = require("tape")
+
+module.exports = testDomComment
+
+function testDomComment(document) {
+    var cleanup = require('./cleanup')(document)
+
+    test("can createComment", function(assert) {
+        var comment = document.createComment("test")
+        assert.equal(comment.data, "test")
+        assert.equal(comment.length, 4)
+        assert.equal(comment.nodeName, "#comment")
+        assert.equal(comment.nodeType, 8)
+        assert.equal(comment.nodeValue, "test")
+        assert.equal(comment.ownerDocument, document)
+        assert.equal(comment.toString(), "[object Comment]")
+        cleanup()
+        assert.end()
+    })
+}

--- a/test/test-dom-element.js
+++ b/test/test-dom-element.js
@@ -94,6 +94,9 @@ function testDomElement(document) {
 
         e1.appendChild(e2)
         e2.appendChild(e3)
+        // non-elements should be ignored
+        e3.appendChild(document.createTextNode('foo'))
+        e3.appendChild(document.createComment('bar'))
 
         var elems = e1.getElementsByTagName("*")
 
@@ -101,6 +104,14 @@ function testDomElement(document) {
         assert.equal(elems[0].tagName, "P")
         assert.equal(elems[1].tagName, "SPAN")
 
+        cleanup()
+        assert.end()
+    })
+
+    test("can serialize comment nodes", function(assert) {
+        var div = document.createElement("div")
+        div.appendChild(document.createComment("test"))
+        assert.equal(div.toString(), "<div><!--test--></div>")
         cleanup()
         assert.end()
     })


### PR DESCRIPTION
Trying to get the bare minimum functionality needed for my knockout.js-related tests to run, and this makes them not immediately throw at least. (Yeah...their template engine gives semantics to HTML comments.)

This builds on the getElementsByTagName PR since that should only return DOMElement nodes if you use `*`.

I kept the output of Comment.prototype.toString how it is IRL(?) by returning `[object Comment]`, but I'm not sure if you want to emulate things like that. Tests are failing in the browser because things like `[object HTMLDivElement]` are expected in places, so dunno :)

I saw in https://github.com/Raynos/min-document/issues/14 that you want to avoid getters, but it seems those are needed for firstChild/nextSibling/etc. too...not that I need to implement those right now.