### PR TITLE
Handle void elements, HTML escaping in serialization code

### DIFF
--- a/test/test-document.js
+++ b/test/test-document.js
@@ -30,17 +30,16 @@ function testDocument(document) {
 
         var span = document.createElement("span")
         div.appendChild(span)
-        span.textContent = "Hello!"
+        span.textContent = "Hello! <&>"
 
         var html = String(div.outerHTML || div)
 
         assert.equal(html, "<div class=\"foo bar\">" +
-            "<span>Hello!</span></div>")
+            "<span>Hello! &lt;&amp;&gt;</span></div>")
 
         cleanup()
         assert.end()
     })
-
 
     test("can createDocumentFragment", function (assert) {
         var frag = document.createDocumentFragment()
@@ -328,7 +327,7 @@ function testDocument(document) {
     test("input has type=text by default", function (assert) {
         var elem = document.createElement("input")
         assert.equal(elem.type, "text");
-        assert.equal(elemString(elem), "<input type=\"text\"></input>")
+        assert.equal(elemString(elem), "<input type=\"text\" />")
         assert.end()
     })
 

--- a/test/test-dom-element.js
+++ b/test/test-dom-element.js
@@ -60,8 +60,8 @@ function testDomElement(document) {
 
     test("does not serialize innerText as an attribute", function(assert) {
       var div = document.createElement("div")
-      div.innerText = "Test"
-      assert.equal(div.toString(), "<div>Test</div>")
+      div.innerText = "Test <&>"
+      assert.equal(div.toString(), "<div>Test &lt;&amp;&gt;</div>")
       cleanup()
       assert.end()
     })
@@ -112,6 +112,22 @@ function testDomElement(document) {
         var div = document.createElement("div")
         div.appendChild(document.createComment("test"))
         assert.equal(div.toString(), "<div><!--test--></div>")
+        cleanup()
+        assert.end()
+    })
+
+    test("can serialize text nodes", function(assert) {
+        var div = document.createElement("div")
+        div.appendChild(document.createTextNode('<test> "&'))
+        assert.equal(div.toString(), '<div>&lt;test&gt; "&amp;</div>')
+        cleanup()
+        assert.end()
+    })
+
+    test("escapes serialized attribute values", function(assert) {
+        var div = document.createElement("div")
+        div.setAttribute("data-foo", '<p>"&')
+        assert.equal(div.toString(), '<div data-foo="&lt;p&gt;&quot;&amp;"></div>')
         cleanup()
         assert.end()
     })


### PR DESCRIPTION
This makes the serialized HTML valid so it can be used by outside tools.