### PR TITLE
Fix behavior of getElement* methods

### DIFF
--- a/docs.mli
+++ b/docs.mli
@@ -99,17 +99,14 @@ type Document := {
     getElementById: (
         this: Document,
         id: String,
-        parent?: DOMElement
     ) => null | DOMElement,
     getElementsByClassName: (
         this: Document,
         className: String
-        parent?: DOMElement
     ) => Array<DOMElement>,
     getElementsByTagName: (
         this: Document,
         tagName: String
-        parent?: DOMElement
     ) => Array<DOMElement>
 }
 

--- a/document.js
+++ b/document.js
@@ -51,71 +51,20 @@ proto.createComment = function createComment(data) {
     return new Comment(data, this)
 }
 
-proto.getElementById = function getElementById(id, parent) {
-    if (!parent) {
-        parent = this.body
-    }
+proto.getElementById = function getElementById(id) {
+    id = String(id)
 
-    if (String(parent.id) === String(id)) {
-        return parent
-    }
-
-    var arr = parent.childNodes
-    var result = null
-
-    if (!arr) {
-        return result
-    }
-
-    for (var i = 0, len = arr.length; !result && i < len; i++) {
-        result = getElementById(id, arr[i])
-    }
-
-    return result
-}
-
-proto.getElementsByClassName = function getElementsByClassName(classNames, parent) {
-    var classes = classNames.split(" ");
-
-    if (!parent) {
-        parent = this.body
-    }
-
-    var elems = []
-
-    domWalk(parent, function (node) {
-        if (node.nodeType === 1) {
-            var nodeClassName = node.className || ""
-            var nodeClasses = nodeClassName.split(" ")
-
-            if (classes.every(function (item) {
-                return nodeClasses.indexOf(item) !== -1
-            })) {
-                elems.push(node)
-            }
+    var result = domWalk(this.childNodes, function (node) {
+        if (String(node.id) === id) {
+            return node
         }
     })
 
-    return elems
+    return result || null
 }
 
-proto.getElementsByTagName = function getElementsByTagName(tagName, parent) {
-    tagName = tagName.toLowerCase()
-
-    if (!parent) {
-        parent = this
-    }
-
-    var elems = []
-
-    domWalk(parent.childNodes, function (node) {
-        if (node.nodeType === 1 && (tagName === '*' || node.tagName.toLowerCase() === tagName)) {
-            elems.push(node)
-        }
-    })
-
-    return elems
-}
+proto.getElementsByClassName = DOMElement.prototype.getElementsByClassName
+proto.getElementsByTagName = DOMElement.prototype.getElementsByTagName
 
 proto.removeEventListener = removeEventListener
 proto.addEventListener = addEventListener

--- a/dom-element.js
+++ b/dom-element.js
@@ -1,3 +1,4 @@
+var domWalk = require("dom-walk")
 var dispatchEvent = require("./event/dispatch-event.js")
 var addEventListener = require("./event/add-event-listener.js")
 var removeEventListener = require("./event/remove-event-listener.js")
@@ -145,9 +146,34 @@ DOMElement.prototype.toString = function _Element_toString() {
 }
 
 DOMElement.prototype.getElementsByClassName = function _Element_getElementsByClassName(classNames) {
-    return this.ownerDocument.getElementsByClassName(classNames, this)
+    var classes = classNames.split(" ");
+    var elems = []
+
+    domWalk(this, function (node) {
+        if (node.nodeType === 1) {
+            var nodeClassName = node.className || ""
+            var nodeClasses = nodeClassName.split(" ")
+
+            if (classes.every(function (item) {
+                return nodeClasses.indexOf(item) !== -1
+            })) {
+                elems.push(node)
+            }
+        }
+    })
+
+    return elems
 }
 
 DOMElement.prototype.getElementsByTagName = function _Element_getElementsByTagName(tagName) {
-    return this.ownerDocument.getElementsByTagName(tagName, this)
+    tagName = tagName.toLowerCase()
+    var elems = []
+
+    domWalk(this.childNodes, function (node) {
+        if (node.nodeType === 1 && (tagName === '*' || node.tagName.toLowerCase() === tagName)) {
+            elems.push(node)
+        }
+    })
+
+    return elems
 }

--- a/test/test-document.js
+++ b/test/test-document.js
@@ -423,6 +423,56 @@ function testDocument(document) {
         assert.end()
     })
 
+    test("getElement* methods search outside the body", function(assert) {
+        var html = document.documentElement;
+        assert.equal(document.getElementsByTagName("html")[0], html)
+
+        html.id = "foo"
+        assert.equal(document.getElementById("foo"), html)
+
+        html.className = "bar"
+        assert.equal(document.getElementsByClassName("bar")[0], html)
+
+        // cleanup
+        html.id = ""
+        html.className = ""
+
+        cleanup()
+        assert.end()
+    })
+
+    test("getElement* methods can be passed to map()", function(assert) {
+        var e1 = document.createElement("div")
+        var e2 = document.createElement("span")
+
+        document.body.appendChild(e1)
+        document.body.appendChild(e2)
+
+        assert.deepEqual(
+            ["div", "span"].map(document.getElementsByTagName.bind(document)),
+            [[e1], [e2]]
+        )
+
+        e1.id = "1"
+        e2.id = "2"
+
+        assert.deepEqual(
+            ["1", "2"].map(document.getElementById.bind(document)),
+            [e1, e2]
+        )
+
+        e1.className = "foo"
+        e2.className = "bar"
+
+        assert.deepEqual(
+            ["foo", "bar"].map(document.getElementsByClassName.bind(document)),
+            [[e1], [e2]]
+        )
+
+        cleanup()
+        assert.end()
+    })
+
     test("can do events", function (assert) {
         var x = 1
         function incx() { x++ }

--- a/test/test-dom-element.js
+++ b/test/test-dom-element.js
@@ -108,6 +108,30 @@ function testDomElement(document) {
         assert.end()
     })
 
+    test("getElement* methods can be passed to map()", function(assert) {
+        var container = document.createElement("div")
+        var e1 = document.createElement("div")
+        var e2 = document.createElement("span")
+        container.appendChild(e1)
+        container.appendChild(e2)
+
+        assert.deepEqual(
+            ["div", "span"].map(container.getElementsByTagName.bind(container)),
+            [[e1], [e2]]
+        )
+
+        e1.className = "foo"
+        e2.className = "bar"
+
+        assert.deepEqual(
+            ["foo", "bar"].map(container.getElementsByClassName.bind(container)),
+            [[e1], [e2]]
+        )
+
+        cleanup()
+        assert.end()
+    })
+
     test("can serialize comment nodes", function(assert) {
         var div = document.createElement("div")
         div.appendChild(document.createComment("test"))


### PR DESCRIPTION
 1. Makes it so you can pass them to map()
 2. Makes the document ones start from the document, not the body

For (2), instead of passing the start node as the second argument, the methods assume `this` is the start node. As it turns out, removing the second argument also fixes (1), because it no longer conflicts with the map index variable.

This does change the API but I dunno if anyone was legitimately using the `parent` arguments since they wouldn't have worked in the browser...