### PR TITLE
Add hasAttribute support

### DIFF
--- a/dom-element.js
+++ b/dom-element.js
@@ -120,6 +120,12 @@ DOMElement.prototype.removeAttributeNS =
         }
     }
 
+DOMElement.prototype.hasAttributeNS =
+    function _Element_hasAttributeNS(namespace, name) {
+        var attributes = this._attributes[namespace]
+        return !!attributes && name in attributes;
+    }
+
 DOMElement.prototype.setAttribute = function _Element_setAttribute(name, value) {
     return this.setAttributeNS(null, name, value)
 }
@@ -130,6 +136,10 @@ DOMElement.prototype.getAttribute = function _Element_getAttribute(name) {
 
 DOMElement.prototype.removeAttribute = function _Element_removeAttribute(name) {
     return this.removeAttributeNS(null, name)
+}
+
+DOMElement.prototype.hasAttribute = function _Element_hasAttribute(name) {
+    return this.hasAttributeNS(null, name)
 }
 
 DOMElement.prototype.removeEventListener = removeEventListener

--- a/test/test-document.js
+++ b/test/test-document.js
@@ -335,14 +335,17 @@ function testDocument(document) {
         var elem = document.createElement("div")
         assert.equal(elem.getAttribute("foo"), null)
         assert.equal(elemString(elem), "<div></div>")
+        assert.notOk(elem.hasAttribute('foo'))
 
         elem.setAttribute("foo", "bar")
         assert.equal(elem.getAttribute("foo"), "bar")
         assert.equal(elemString(elem), "<div foo=\"bar\"></div>")
+        assert.ok(elem.hasAttribute('foo'))
 
         elem.removeAttribute("foo")
         assert.equal(elem.getAttribute("foo"), null)
         assert.equal(elemString(elem), "<div></div>")
+        assert.notOk(elem.hasAttribute('foo'))
 
         assert.end()
     })


### PR DESCRIPTION
Required by https://github.com/Colingo/form-data-set for via `<input type="checkbox">`. Right now you can test value-events for checkboxes against min-document.