### PR TITLE
Fix serialization of namespaced attributes.

### DIFF
--- a/dom-element.js
+++ b/dom-element.js
@@ -96,20 +96,26 @@ DOMElement.prototype.insertBefore =
 
 DOMElement.prototype.setAttributeNS =
     function _Element_setAttributeNS(namespace, name, value) {
+        var prefix = null
+        var localName = name
         var colonPosition = name.indexOf(":")
-        var localName = colonPosition > -1 ? name.substr(colonPosition + 1) : name
+        if (colonPosition > -1) {
+            prefix = name.substr(0, colonPosition)
+            localName = name.substr(colonPosition + 1)
+        }
         var attributes = this._attributes[namespace] || (this._attributes[namespace] = {})
-        attributes[localName] = value
+        attributes[localName] = {value: value, prefix: prefix}
     }
 
 DOMElement.prototype.getAttributeNS =
     function _Element_getAttributeNS(namespace, name) {
         var attributes = this._attributes[namespace];
-        if (!(attributes && typeof attributes[name] === "string")) {
+        var value = attributes && attributes[name] && attributes[name].value
+        if (typeof value !== "string") {
             return null
         }
 
-        return attributes[name]
+        return value
     }
 
 DOMElement.prototype.removeAttributeNS =

--- a/serialize.js
+++ b/serialize.js
@@ -100,8 +100,9 @@ function properties(elem) {
 
     for (var ns in elem._attributes) {
       for (var attribute in elem._attributes[ns]) {
-        var name = (ns !== "null" ? ns + ":" : "") + attribute
-        props.push({ name: name, value: elem._attributes[ns][attribute] })
+        var prop = elem._attributes[ns][attribute]
+        var name = (prop.prefix ? prop.prefix + ":" : "") + attribute
+        props.push({ name: name, value: prop.value })
       }
     }
 

--- a/test/test-document.js
+++ b/test/test-document.js
@@ -374,6 +374,7 @@ function testDocument(document) {
         assert.equal(elem.getAttributeNS(ns, "myattr"), blankAttributeNS())
         elem.setAttributeNS(ns, "myns:myattr", "the value")
         assert.equal(elem.getAttributeNS(ns, "myattr"), "the value")
+        assert.equal(elemString(elem), '<div myns:myattr="the value"></div>')
         elem.removeAttributeNS(ns, "myattr")
         assert.equal(elem.getAttributeNS(ns, "myattr"), blankAttributeNS())
 


### PR DESCRIPTION
Serializing an image with an xlink:href="myimage.jpg" attribute would produce:
<image http://www.w3.org/1999/xlink:href="myimage.jpg"></image>

This patch fixes serialization by storing both the local name and the profix
of namespaced attributes in setAttributeNS and then using the stored prefix
value for serialization.