### PR TITLE
Handle attribute values that are boolean or blank

### DIFF
--- a/serialize.js
+++ b/serialize.js
@@ -84,7 +84,13 @@ function stringify(list) {
             value = stylify(value)
         }
 
-        attributes.push(name + "=" + "\"" + escapeAttributeValue(value) + "\"")
+        if (value === null || value === undefined || value === false) {
+          // nothing
+        } else if (value === true) {
+          attributes.push(name)
+        } else {
+          attributes.push(name + "=" + "\"" + escapeAttributeValue(value) + "\"")
+        }
     })
 
     return attributes.length ? " " + attributes.join(" ") : ""


### PR DESCRIPTION
When trying to serialize a DOMElement that has an attribute set to a boolean or is blank, the current behaviour doesn't handle this well.
