### PR TITLE
Add nodeName property to text nodes

### DIFF
--- a/dom-element.js
+++ b/dom-element.js
@@ -16,6 +16,7 @@ function DOMElement(tagName, owner, namespace) {
     var ns = namespace === undefined ? htmlns : (namespace || null)
 
     this.tagName = ns === htmlns ? String(tagName).toUpperCase() : tagName
+    this.nodeName = this.tagName
     this.className = ""
     this.dataset = {}
     this.childNodes = []

--- a/dom-text.js
+++ b/dom-text.js
@@ -12,6 +12,7 @@ function DOMText(value, owner) {
 
 DOMText.prototype.type = "DOMTextNode"
 DOMText.prototype.nodeType = 3
+DOMText.prototype.nodeName = "#text"
 
 DOMText.prototype.toString = function _Text_toString() {
     return this.data


### PR DESCRIPTION
The `nodeName` property of text nodes should be `'#text'` to be consistent with browsers ([reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName)).