### PR TITLE
Default type on input set as attribute

### DIFF
--- a/dom-element.js
+++ b/dom-element.js
@@ -27,7 +27,7 @@ function DOMElement(tagName, owner, namespace) {
     this._attributes = {}
 
     if (this.tagName === 'INPUT') {
-      this.type = 'text'
+      this.setAttribute('type', 'text')
     }
 }
 

--- a/dom-element.js
+++ b/dom-element.js
@@ -16,6 +16,7 @@ function DOMElement(tagName, owner, namespace) {
     var ns = namespace === undefined ? htmlns : (namespace || null)
 
     this.tagName = ns === htmlns ? String(tagName).toUpperCase() : tagName
+    this.nodeName = this.tagName
     this.className = ""
     this.dataset = {}
     this.childNodes = []
@@ -26,7 +27,7 @@ function DOMElement(tagName, owner, namespace) {
     this._attributes = {}
 
     if (this.tagName === 'INPUT') {
-      this.type = 'text';
+      this.type = 'text'
     }
 }
 

--- a/dom-element.js
+++ b/dom-element.js
@@ -16,7 +16,6 @@ function DOMElement(tagName, owner, namespace) {
     var ns = namespace === undefined ? htmlns : (namespace || null)
 
     this.tagName = ns === htmlns ? String(tagName).toUpperCase() : tagName
-    this.nodeName = this.tagName
     this.className = ""
     this.dataset = {}
     this.childNodes = []
@@ -27,7 +26,7 @@ function DOMElement(tagName, owner, namespace) {
     this._attributes = {}
 
     if (this.tagName === 'INPUT') {
-      this.setAttribute('type', 'text')
+      this.type = 'text';
     }
 }
 
@@ -104,18 +103,25 @@ DOMElement.prototype.setAttributeNS =
             prefix = name.substr(0, colonPosition)
             localName = name.substr(colonPosition + 1)
         }
-        var attributes = this._attributes[namespace] || (this._attributes[namespace] = {})
-        attributes[localName] = {value: value, prefix: prefix}
+        if (this.tagName === 'INPUT' && name === 'type') {
+          this.type = value;
+        }
+        else {
+          var attributes = this._attributes[namespace] || (this._attributes[namespace] = {})
+          attributes[localName] = {value: value, prefix: prefix}
+        }
     }
 
 DOMElement.prototype.getAttributeNS =
     function _Element_getAttributeNS(namespace, name) {
         var attributes = this._attributes[namespace];
         var value = attributes && attributes[name] && attributes[name].value
+        if (this.tagName === 'INPUT' && name === 'type') {
+          return this.type;
+        }
         if (typeof value !== "string") {
             return null
         }
-
         return value
     }
 

--- a/test/test-document.js
+++ b/test/test-document.js
@@ -326,8 +326,16 @@ function testDocument(document) {
 
     test("input has type=text by default", function (assert) {
         var elem = document.createElement("input")
-        assert.equal(elem.type, "text");
+        assert.equal(elem.getAttribute("type"), "text");
         assert.equal(elemString(elem), "<input type=\"text\" />")
+        assert.end()
+    })
+
+    test("input type=text can be overridden", function (assert) {
+        var elem = document.createElement("input")
+        elem.setAttribute("type", "hidden")
+        assert.equal(elem.getAttribute("type"), "hidden");
+        assert.equal(elemString(elem), "<input type=\"hidden\" />")
         assert.end()
     })
 


### PR DESCRIPTION
This is my test case:

```
const bel = require('bel');
console.log(bel`<input type="hidden" name="name" value="value" />`.toString());
```

Which currently outputs `<input type="text" type="hidden" name="test" value="" />` when min-document is being used via global, within node.

I'm not sure where or why the type property is rendered as an attribute, but it seems like it should be set as an attribute rather than a property, which removes the duplicate rendered attribute.