### PR TITLE
fix <input type=X> behavior

### DIFF
--- a/dom-element.js
+++ b/dom-element.js
@@ -27,7 +27,7 @@ function DOMElement(tagName, owner, namespace) {
     this._attributes = {}
 
     if (this.tagName === 'INPUT') {
-      this.type = 'text'
+      this.setAttribute('type', 'text')
     }
 }
 

--- a/test/test-document.js
+++ b/test/test-document.js
@@ -326,8 +326,10 @@ function testDocument(document) {
 
     test("input has type=text by default", function (assert) {
         var elem = document.createElement("input")
-        assert.equal(elem.type, "text");
+        assert.equal(elem.getAttribute("type"), "text");
         assert.equal(elemString(elem), "<input type=\"text\" />")
+        elem.setAttribute("type", "file")
+        assert.equal(elemString(elem), "<input type=\"file\" />")
         assert.end()
     })
 


### PR DESCRIPTION
Before you would get `<input type="text" type="file">`. Also setting `this.type = 'text'` was shadowing `DOMElement.prototype.type = "DOMElement"`.