### PR TITLE
Handle non string attribute/property value

### DIFF
--- a/serialize.js
+++ b/serialize.js
@@ -51,7 +51,7 @@ function isProperty(elem, key) {
     }
 
     return elem.hasOwnProperty(key) &&
-        (type === "string" || type === "boolean" || type === "number") &&
+        (type === "string" || (type === "boolean" && elem[key]) || type === "number") &&
         key !== "nodeName" && key !== "className" && key !== "tagName" &&
         key !== "textContent" && key !== "innerText" && key !== "namespaceURI" &&  key !== "innerHTML"
 }
@@ -120,15 +120,7 @@ function properties(elem) {
 }
 
 function escapeText(s) {
-    var str = '';
-
-    if (typeof(s) === 'string') { 
-        str = s; 
-    } else if (s) {
-        str = s.toString();
-    }
-
-    return str
+    return String(s)
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;")

--- a/test/test-dom-element.js
+++ b/test/test-dom-element.js
@@ -201,9 +201,23 @@ function testDomElement(document) {
     test("can handle non string attribute values", function(assert) {
         var div = document.createElement("div")
         div.setAttribute("data-number", 100)
+        div.setAttribute("data-zero", 0)
         div.setAttribute("data-boolean", true)
+        div.setAttribute("data-false", false)
         div.setAttribute("data-null", null)
-        assert.equal(div.toString(), '<div data-number="100" data-boolean="true" data-null=""></div>')
+        assert.equal(div.toString(), '<div data-number="100" data-zero="0" data-boolean="true" data-false="false" data-null="null"></div>')
+        cleanup()
+        assert.end()
+    })
+
+    test("can handle non string property values", function(assert) {
+        var div = document.createElement("div")
+        div.id = 100
+        div.title = 0
+        div.contentEditable = true
+        div.selected = false
+        div.className = null
+        assert.equal(div.toString(), '<div id="100" title="0" contentEditable="true"></div>')
         cleanup()
         assert.end()
     })


### PR DESCRIPTION
Everyone is discussing serialization #20 #31 , it's complex. How about this simple PR?

Fixed:

1. Any attribute can be stringified if you set it by `setAttribute`. So :

    - `div.setAttribute('data-null', null)` should be serialized to `<div data-null="null"></div>` instead of `<div data-null=""></div>`

    -  `div.setAttribute('data-number', 0)` should be serialized to `<div data-number="0"></div>` instead of `<div data-number=""></div>`

2. The `false` property should not be serialized. So:

    - `option.selected = false` should be serialized to `<option></option>` instead of `<option selected=""></option>`