### PR TITLE
Update license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,7 @@
     "tap-spec": "^0.1.8",
     "tape": "^2.12.3"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/Raynos/min-document/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "test": "node ./test/index.js | tap-spec",
     "dot": "node ./test/index.js | tap-dot",


### PR DESCRIPTION
It appears that "licenses" is now deprecated
https://docs.npmjs.com/files/package.json#license