### PR TITLE
Handle `id` and `className` attributes

### DIFF
--- a/dom-element.js
+++ b/dom-element.js
@@ -104,6 +104,12 @@ DOMElement.prototype.setAttributeNS =
             prefix = name.substr(0, colonPosition)
             localName = name.substr(colonPosition + 1)
         }
+        if (name === 'id') {
+          this.id = value
+        }
+        if (name === 'class') {
+          this.className = value
+        }
         if (this.tagName === 'INPUT' && name === 'type') {
           this.type = value;
         }

--- a/dom-element.js
+++ b/dom-element.js
@@ -32,28 +32,28 @@ function DOMElement(tagName, owner, namespace) {
     var _id
     var _className
     Object.defineProperties(this, {
-      id: {
-        enumerable: true,
-        get: function () {
-          return _id
+        id: {
+            enumerable: true,
+            get: function () {
+            return _id
         },
-        set: function (newVal) {
-          if (_id === newVal) return
-          _id = newVal
-          this.setAttribute('id', _id)
-        }
-      },
-      className: {
-        enumerable: true,
-        get: function () {
-          return _className
+            set: function (newVal) {
+                if (_id === newVal) return
+                _id = newVal
+                this.setAttribute('id', _id)
+            }
         },
-        set: function (newVal) {
-          if (_className === newVal) return
-          _className = newVal
-          this.setAttribute('class', _className)
+        className: {
+            enumerable: true,
+            get: function () {
+              return _className
+            },
+            set: function (newVal) {
+                if (_className === newVal) return
+                _className = newVal
+                this.setAttribute('class', _className)
+            }
         }
-      }
     })
 }
 

--- a/dom-element.js
+++ b/dom-element.js
@@ -35,8 +35,8 @@ function DOMElement(tagName, owner, namespace) {
         id: {
             enumerable: true,
             get: function () {
-            return _id
-        },
+                return _id
+            },
             set: function (newVal) {
                 if (_id === newVal) return
                 _id = newVal

--- a/dom-element.js
+++ b/dom-element.js
@@ -17,7 +17,6 @@ function DOMElement(tagName, owner, namespace) {
 
     this.tagName = ns === htmlns ? String(tagName).toUpperCase() : tagName
     this.nodeName = this.tagName
-    this.className = ""
     this.dataset = {}
     this.childNodes = []
     this.parentNode = null
@@ -29,6 +28,33 @@ function DOMElement(tagName, owner, namespace) {
     if (this.tagName === 'INPUT') {
       this.type = 'text'
     }
+    
+    var _id
+    var _className
+    Object.defineProperties(this, {
+      id: {
+        enumerable: true,
+        get: function () {
+          return _id
+        },
+        set: function (newVal) {
+          if (_id === newVal) return
+          _id = newVal
+          this.setAttribute('id', _id)
+        }
+      },
+      className: {
+        enumerable: true,
+        get: function () {
+          return _className
+        },
+        set: function (newVal) {
+          if (_className === newVal) return
+          _className = newVal
+          this.setAttribute('class', _className)
+        }
+      }
+    })
 }
 
 DOMElement.prototype.type = "DOMElement"

--- a/serialize.js
+++ b/serialize.js
@@ -53,7 +53,8 @@ function isProperty(elem, key) {
     return elem.hasOwnProperty(key) &&
         (type === "string" || type === "boolean" || type === "number") &&
         key !== "nodeName" && key !== "className" && key !== "tagName" &&
-        key !== "textContent" && key !== "innerText" && key !== "namespaceURI" &&  key !== "innerHTML"
+        key !== "textContent" && key !== "innerText" && key !== "namespaceURI" &&
+        key !== "id" && key !== "innerHTML"
 }
 
 function stylify(styles) {

--- a/serialize.js
+++ b/serialize.js
@@ -112,10 +112,6 @@ function properties(elem) {
       }
     }
 
-    if (elem.className) {
-        props.push({ name: "class", value: elem.className })
-    }
-
     return props.length ? stringify(props) : ""
 }
 

--- a/test/test-dom-element.js
+++ b/test/test-dom-element.js
@@ -57,6 +57,14 @@ function testDomElement(document) {
         cleanup()
         assert.end()
     })
+    
+    test("setAttribute will properly affect id and className property", function (assert) {
+      var div = document.createElement("div")
+      div.setAttribute("class", "my-class")
+      console.log(div.toString())
+      assert.equal(div.toString(), "<div class=\"my-class\"></div>")
+      assert.end()
+    })
 
     test("does not serialize innerText as an attribute", function(assert) {
       var div = document.createElement("div")

--- a/test/test-dom-element.js
+++ b/test/test-dom-element.js
@@ -58,11 +58,19 @@ function testDomElement(document) {
         assert.end()
     })
     
-    test("setAttribute will properly affect id and className property", function (assert) {
+    test("setAttribute will properly affect className property", function(assert) {
       var div = document.createElement("div")
       div.setAttribute("class", "my-class")
-      console.log(div.toString())
       assert.equal(div.toString(), "<div class=\"my-class\"></div>")
+      assert.equal(div.className, "my-class")
+      assert.end()
+    })
+    
+    test("setAttribute will properly affect id property", function(assert) {
+      var div = document.createElement("div")
+      div.setAttribute("id", "my-id")
+      assert.equal(div.toString(), "<div id=\"my-id\"></div>")
+      assert.equal(div.id, "my-id")
       assert.end()
     })
 


### PR DESCRIPTION
I was using `bel` + `cssauron-html` to do some component testing in a completely node environment. In this case, bel uses this module to create the document structure. However, the elements were being created with empty `id` and `className` attributes. 

The id and className properties on elements need to be handled a bit uniquely (others too I think but for now this is what I'm running into)


In a browser environment:
```
var el = document.createElement('div')

el.setAttribute('class', 'my-class')

el.className // returns 'my-class'
```
The reverse is true as well

```
var el = document.createElement('div')

el.className = 'my-class'

el.getAttribute('class') // returns 'my-class'
```

But this isn't working the way it is currently set up. Since setAttribute('class') will not affect className, and changes to className will not the corresponding 'class' to attributes.

So two changes

1. setAttribute now handles `id` and `className` in a way that will put them directly on the dom element in addition to adding them to `_attributes` object
2. `id` and `className` use object-defined wrapped setters so `setAttribute` can be called behind the scenes whenever these properties are set via the `.` operator
3. Add tests to ensure these now behave as they do in the browser

This accurately mimics dom elements' behavior, so `cssauron-html` can work with `bel` in node from some pretty awesome testing :)