### PR TITLE
Fix prototype pollution vulnerability in removeAttributeNS

### DIFF
--- a/dom-element.js
+++ b/dom-element.js
@@ -128,7 +128,10 @@ DOMElement.prototype.getAttributeNS =
 
 DOMElement.prototype.removeAttributeNS =
     function _Element_removeAttributeNS(namespace, name) {
-        // Safely access and delete the attribute
+        // Prevent prototype pollution by checking if namespace is a direct property
+        if (!Object.prototype.hasOwnProperty.call(this._attributes, namespace)) {
+            return;
+        }
         var attributes = this._attributes[namespace];
         if (attributes && Object.prototype.hasOwnProperty.call(attributes, name)) {
             delete attributes[name];


### PR DESCRIPTION
## Overview

The following issue occurred in v2.19.0 and was fixed in https://github.com/Raynos/min-document/pull/55

```bash
$ npm i min-document@2.19.0
$ wget https://raw.githubusercontent.com/OrangeShieldInfos/PoCs/refs/heads/main/JavaScript/prototype-pollution/CVE-2025-57352/index.js
$ cat index.js
const clazz = require("min-document/dom-element");
let instance = new clazz();
instance.removeAttributeNS('__proto__', 'toString');
console.log({}.toString ? '':'[DELETE_TRIGGERED]');
$ node index.js
[DELETE_TRIGGERED]
```

However, the fix was incomplete, and the issue persists, as shown in the snippet.

```bash
$ npm i min-document
$ node index.js
[DELETE_TRIGGERED]
```

The prototype pollution vulnerability still exists because the `namespace` parameter wasn't validated before accessing `this._attributes[namespace]`.
When `namespace = "__proto__"`, the code evaluates `this._attributes.__proto__` which references `Object.prototype`, allowing pollution of the prototype chain.

## Solution

Add namespace validation before property access:
https://github.com/wasabina67/min-document/blob/966646172d9063f880aeaf79882edfc3a0ceaca4/dom-element.js#L129-L139

```bash
$ cat poc.js
var Document = require('./document.js');
var doc = new Document();
var el = doc.createElement('div');
el.removeAttributeNS('__proto__', 'toString');
console.log({}.toString ? '':'[DELETE_TRIGGERED]');
$ node poc.js

$
```
